### PR TITLE
Bug job description error

### DIFF
--- a/server/controllers/jobSearchController.js
+++ b/server/controllers/jobSearchController.js
@@ -37,9 +37,9 @@ exports.scrapeDescription = (req, res) => {
 
       const $ = cheerio.load(html);
       const description = $('.content');
-      res.send(description.html());
+      res.status(200).send(description.html());
     })
-    .catch((err) => res.send(err));
+    .catch((err) => res.status(404).send(err));
 };
 
 exports.jobSearch = (req, res) => {

--- a/src/app/components/JobsList/JobFocusItem.jsx
+++ b/src/app/components/JobsList/JobFocusItem.jsx
@@ -2,7 +2,6 @@ import { useState, useEffect } from 'react';
 import * as React from 'react';
 import axios from 'axios';
 import Card from '@mui/material/Card';
-import CardActions from '@mui/material/CardActions';
 import CardContent from '@mui/material/CardContent';
 import Typography from '@mui/material/Typography';
 
@@ -16,7 +15,11 @@ function JobFocusItem({ job }) {
       },
     })
       .then((results) => {
-        // setDescription(results.data);
+        setDescription(results.data);
+      })
+      .catch((error) => {
+        console.log('Failed to retreive job description, falling back to snippet', error);
+        setDescription(job.description);
       });
   });
 

--- a/src/app/components/JobsList/JobFocusItem.jsx
+++ b/src/app/components/JobsList/JobFocusItem.jsx
@@ -8,7 +8,9 @@ import Typography from '@mui/material/Typography';
 function JobFocusItem({ job }) {
   const [description, setDescription] = useState(job.description);
 
+  // When we polish Description to show HTML please remove the template literals in this useEffect.
   useEffect(() => {
+    setDescription(`${job.description} Loading Full Job Description, Please Wait`);
     axios.get('/data/jobsearchdescription', {
       params: {
         url: job.url,
@@ -18,16 +20,10 @@ function JobFocusItem({ job }) {
         setDescription(results.data);
       })
       .catch((error) => {
-        console.log('Failed to retreive job description, falling back to snippet', error);
-        setDescription(job.description);
+        console.log('Failed to retreive full job description, falling back to snippet', error);
+        setDescription(`${job.description} Full Job Description unavailable for this job at this time`);
       });
-  });
-
-  console.log(job.company);
-  console.log(job.title);
-  console.log(job.locations);
-  console.log(description);
-  console.log(job.date);
+  }, [job.description, job.url]);
 
   if (job) {
     return (


### PR DESCRIPTION
Job Description will now handle a failed get of the Full Job Description by displaying the short snippet version of the description with an addition to the message stating that the full description is unavailable.

Job Description only runs once per job/Learn More clicked.

If you click on the same Learn More button, it will not request a job description again.

When waiting on Job Description to load, the short snippet version is displayed with a small additional message stating that Loading is in progress.

Anyone may review.